### PR TITLE
Fix cspot plugin and autocreate configuration directory

### DIFF
--- a/euphonium/src/plugins/cspot/CSpotPlugin.cpp
+++ b/euphonium/src/plugins/cspot/CSpotPlugin.cpp
@@ -83,6 +83,11 @@ void CSpotPlugin::runTask() {
         mercuryManager->startTask();
         auto audioSink = std::make_shared<FakeAudioSink>(this->audioBuffer,
                                                          this->luaEventBus);
+
+        while (!mercuryManager->isRunning) {
+            BELL_SLEEP_MS(10);
+        }
+
         spircController = std::make_shared<SpircController>(
             mercuryManager, authBlob->username, audioSink);
 

--- a/targets/cli/FileScriptLoader.cpp
+++ b/targets/cli/FileScriptLoader.cpp
@@ -1,6 +1,12 @@
 #include <FileScriptLoader.h>
+#include <sys/stat.h>
 
 FileScriptLoader::FileScriptLoader() {
+    struct stat st;
+    if (stat("../../../euphonium/scripts/configuration", &st) != 0 || !S_ISDIR(st.st_mode))
+    {
+        mkdir("../../../euphonium/scripts/configuration", 0755);
+    }
 }
 
 void FileScriptLoader::loadScript(std::string scriptName, std::shared_ptr<berry::VmState> berry) {


### PR DESCRIPTION
feelfreelinux/euphonium@25b218a - On slower devices spawning mercuryManager task takes more time. In the result, SpircController does not function properly. 

feelfreelinux/euphonium@ea49f0d - create configuration directory, as in esp32 target