### PR TITLE
build cli tool in nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,7 @@
           frontend = pkgs.euphonium.frontend;
           fs-esp32 = pkgs.euphonium.fs-esp32;
           app-esp32 = pkgs.euphonium.app-esp32;
+          euphoniumcli = pkgs.euphonium.euphoniumcli;
         };
 
         devShells = {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -67,7 +67,7 @@ rec {
 
     nativeBuildInputs = with pkgs; [ esp-idf fs-esp32 pkg-config bash python39 ];
 
-    # Patch nanopb shebangs to refer ot provided python
+    # Patch nanopb shebangs to refer to provided python
     postPatch = ''
       patchShebangs src/core/external/bell/external/nanopb/generator/*
     '';
@@ -100,5 +100,39 @@ rec {
       cp flash_args $out/
     '';
     dontConfigure = true;
+  };
+
+  # build target cli
+  euphoniumcli = stdenv.mkDerivation {
+    name = "euphoniumcli";
+    src = ../.;
+    dontConfigure = true;
+    nativeBuildInputs = with pkgs; [
+      avahi
+      avahi-compat
+      cmake
+      python3
+      python3Packages.protobuf
+      python3Packages.setuptools
+      unstable.mbedtls
+      portaudio
+      protobuf
+    ];
+    # Patch nanopb shebangs to refer to provided python
+    postPatch = ''
+      patchShebangs src/core/external/bell/external/nanopb/generator/*
+    '';
+    buildPhase = ''
+      cd src/targets/cli
+      cmake . -DCMAKE_SKIP_BUILD_RPATH=ON
+      make -j $NIX_BUILD_CORES
+    '';
+    installPhase = ''
+      mkdir -p $out/bin
+      cp euphoniumcli $out/bin
+
+      mkdir -p $out/lib
+      cp euphonium/bell/external/opencore-aacdec/libopencore-aacdec.so $out/lib
+    '';
   };
 }


### PR DESCRIPTION
Builds the cli tool in Nix.

Might not be ready to merge yet: still doesn't handle integrating the frontend with the cli.

I couldn't figure out how to set where euphonium will search for the index.html file. Right now it's just looking for `../../../core/fs/pkgs/web/dist/index.html`.
I guess that should be set to `${frontend}/index.html`.